### PR TITLE
Fix the bug on updating UserItem

### DIFF
--- a/app/UserItem.php
+++ b/app/UserItem.php
@@ -157,13 +157,14 @@ class UserItem extends Model
      */
     public static function scopeUpdateUserItem(int $id, int $itemId, array $data, string $token)
     {
-        if (Item::scopeItemDetail($itemId)->consumable == 0 && $data['consumed']) {
+        $userItem = self::where('user_id', $id)->find($itemId);
+
+        if (Item::scopeItemDetail($userItem->item_id)->consumable == 0 && $data['consumed']) {
             return response()->json([
                 'message' => 'Bad Request Consumed value is true',
             ], 400);
         }
 
-        $userItem = self::where('user_id', $id)->find($itemId);
         try {
             DB::beginTransaction();
 


### PR DESCRIPTION
PUT /users/?/items/?/ 를 진행할 때

"message": "Trying to get property 'consumable' of non-object" 라는
500 에러가 간혹 발생하는 문제가 생겨 코드를 분석해본 결과

UserItem의 pk와 Item의 fk가 하나의 변수에서 혼용되는 버그가 있었습니다.