### PR TITLE
Fix the bug on User Validation Webhook

### DIFF
--- a/app/Services/XsollaWebhookService.php
+++ b/app/Services/XsollaWebhookService.php
@@ -68,7 +68,7 @@ class XsollaWebhookService
      */
     public function userValidation(array $data)
     {
-        if (User::where('email', $data['user']['id'])->orWhere('name', $data['user']['id'])->first()) {
+        if (User::scopeGetUser((int) $data['user']['id'])) {
             return response([
                 'success' => [
                     'code' => 'VALID_USER',


### PR DESCRIPTION
Xsolla DB에서의 사용자 아이디는 Forte DB의 사용자 pk와 동일하게 되도록
바꿨는데 그와 연계된 userValidation 웹훅을 수정하지 않아 테스트과정에서
문제가 발생했습니다.